### PR TITLE
Adding mysqld_multi.server_lsb-header.patch, provides LSB headers for ex...

### DIFF
--- a/debian/patches/mysqld_multi.server_lsb-header.patch
+++ b/debian/patches/mysqld_multi.server_lsb-header.patch
@@ -1,0 +1,29 @@
+--- a/support-files/mysqld_multi.server.sh
++++ b/support-files/mysqld_multi.server.sh
+@@ -14,8 +14,24 @@
+ # Version 1.0
+ #
+ 
+-basedir=/usr/local/mysql
+-bindir=/usr/local/mysql/bin
++### BEGIN INIT INFO
++# Provides:          mysqld_multi
++# Required-Start:    $remote_fs $syslog
++# Required-Stop:     $remote_fs $syslog
++# Should-Start:      $network $named $time
++# Should-Stop:       $network $named $time
++# Default-Start:     2 3 4 5
++# Default-Stop:      0 1 6
++# Short-Description: Start and stop multiple mysql database server daemon instances
++# Description:       Controls multiple MariaDB database server daemon instances
++### END INIT INFO
++
++PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
++NAME=mysqld_multi
++DESC=mysqld_multi
++
++basedir=/usr
++bindir=/usr/bin
+ 
+ if test -x $bindir/mysqld_multi
+ then

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -13,3 +13,4 @@ new_valid_certs.patch
 new_valid_certs_test_fix.patch
 reproducible-builds-fix-connect.patch
 mysqld_multi_confd.patch
+mysqld_multi.server_lsb-header.patch


### PR DESCRIPTION
...ample initscript
(Closes: #778762)

Anyways ... in some cases it maybe also usefull to provide 'mysql', but that breaks the default init script.