### PR TITLE
Auth sock

### DIFF
--- a/debian/mariadb-server-10.0.postinst
+++ b/debian/mariadb-server-10.0.postinst
@@ -29,20 +29,26 @@ test_passwordless_root_login() {
        mysql --no-defaults -u root -h localhost </dev/null >/dev/null 2>&1
 }
 
-# call with $1 = "online" to connect to the server, otherwise it bootstraps
+# This function resets the root@localhost user password and enable the
+# usage of the unix_socket plugin for it.
+# Call with $1 = "online" to connect to the server, otherwise it bootstraps
 set_mysql_rootpw() {
 
-       tfile=`mktemp`
+       tfile="$(mktemp)"
        if [ ! -f "$tfile" ]; then
                return 1
        fi
 
-       # this avoids us having to call "test" or "[" on $rootpw
+       # The reset_root statement is used to verify that the unix_socket plugin
+       # is active before resetting the root@localhost password ; if the plugin
+       # is not active, it will fail with "ERROR 1065 (42000): Query was empty"
+
+       # This avoids us having to call "test" or "[" on $rootpw
        cat << EOF > $tfile
-USE mysql;
 SET sql_log_bin=0;
-UPDATE user SET password="", plugin="unix_socket" WHERE user='root';
-FLUSH PRIVILEGES;
+SET @reset_root=IF( (SELECT 1 FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME='unix_socket' AND PLUGIN_STATUS='ACTIVE' AND PLUGIN_TYPE='AUTHENTICATION' AND PLUGIN_LIBRARY LIKE CONCAT('auth_socket','%') )=1, "UPDATE mysql.user SET Password='', Plugin='unix_socket' WHERE User='root' AND Host='localhost'", '');
+PREPARE reset_root FROM @reset_root;
+EXECUTE reset_root;
 EOF
        if [ "$1" = "online" ]; then
                mysql --no-defaults -u root -h localhost <$tfile >/dev/null
@@ -51,7 +57,7 @@ EOF
                $MYSQL_BOOTSTRAP <$tfile
                retval=$?
        fi
-       rm -f $tfile
+       rm -f "$tfile"
        return $retval
 }
 

--- a/debian/mariadb-server-10.0.postinst
+++ b/debian/mariadb-server-10.0.postinst
@@ -172,9 +172,8 @@ case "$1" in
 
     # Replace old maintenance user with auth_socket usage if migrating
     replace_query=`/bin/echo -e \
-        "USE mysql;\n" \
         "SET sql_mode='', sql_log_bin=0;\n" \
-        "DROP USER 'debian-sys-maint'@'localhost';"`
+        "DELETE FROM mysql.user WHERE user='debian-sys-maint' AND host='localhost';"`
     # WARNING: This line might yield "The MariaDB server is running with
     # the --skip-grant-tables option so it cannot execute this statement"
 


### PR DESCRIPTION

<pre>
root@spaceman:~# apt-get purge mariadb-server-10.0

root@spaceman:~# cp /share/software_projects/mariadb-10.0-git-ottofork/debian/mariadb-server-10.0.postinst  /var/lib/dpkg/info/mariadb-server-10.0.postinst 

root@spaceman:~# rm -rf /var/lib/mysql               
root@spaceman:~# apt-get install mariadb-server  
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following packages were automatically installed and are no longer required:
  emacsen-common g++-4.7 html2text libarchive12 libclass-isa-perl libffi5 libicu48 libmpc2 libneon27-gnutls libswitch-perl
  libxmlrpc-core-c3 openssh-blacklist openssh-blacklist-extra python-magic wwwconfig-common
Use 'apt-get autoremove' to remove them.
The following NEW packages will be installed:
  mariadb-server
0 upgraded, 1 newly installed, 0 to remove and 2 not upgraded.
1 not fully installed or removed.
Need to get 15.4 kB of archives.
After this operation, 53.2 kB of additional disk space will be used.
Get:1 http://ftp.us.debian.org/debian/ unstable/main mariadb-server all 10.0.16-1 [15.4 kB]
Fetched 15.4 kB in 0s (16.4 kB/s)      
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
        LANGUAGE = "",
        LC_ALL = (unset),
        LANG = "en_AU.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
        LANGUAGE = "",
        LC_ALL = (unset),
        LANG = "en_AU.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
locale: Cannot set LC_CTYPE to default locale: No such file or directory
locale: Cannot set LC_MESSAGES to default locale: No such file or directory
locale: Cannot set LC_ALL to default locale: No such file or directory
Selecting previously unselected package mariadb-server.
(Reading database ... 45083 files and directories currently installed.)
Preparing to unpack .../mariadb-server_10.0.16-1_all.deb ...
Unpacking mariadb-server (10.0.16-1) ...
Setting up mariadb-server-10.0 (10.0.17-1~exp1) ...
+ . /usr/share/debconf/confmodule
++ '[' '!' '' ']'
++ PERL_DL_NONLAZY=1
++ export PERL_DL_NONLAZY
++ '[' '' ']'
++ exec /usr/share/debconf/frontend /var/lib/dpkg/info/mariadb-server-10.0.postinst configure ''
locale: Cannot set LC_CTYPE to default locale: No such file or directory
locale: Cannot set LC_MESSAGES to default locale: No such file or directory
locale: Cannot set LC_ALL to default locale: No such file or directory
+ . /usr/share/debconf/confmodule
++ '[' '!' 1 ']'
++ '[' -z '' ']'
++ exec
++ '[' '' ']'
++ exec
++ DEBCONF_REDIR=1
++ export DEBCONF_REDIR
+ '[' -n '' ']'
+ export PATH=/usr/lib64/ccache:/sbin:/bin:/usr/sbin:/usr/bin:/sbin:/usr/sbin:/bin:/usr/bin
+ PATH=/usr/lib64/ccache:/sbin:/bin:/usr/sbin:/usr/bin:/sbin:/usr/sbin:/bin:/usr/bin
+ ERR_LOGGER='logger -p daemon.err -t mysqld_safe -i'
+ set -o pipefail
+ MYSQL_BOOTSTRAP='/usr/sbin/mysqld --bootstrap --user=mysql --disable-log-bin --skip-grant-tables --default-storage-engine=myisam --plugin-load-add=auth_socket'
+ set +e
+ invoke stop
+ '[' -x /usr/sbin/invoke-rc.d ']'
+ invoke-rc.d mysql stop
[FAIL] Stopping MariaDB database server: mysqld failed!
invoke-rc.d: initscript mysql, action "stop" failed.
+ set -e
+ case "$1" in
+ mysql_statedir=/usr/share/mysql
+ mysql_datadir=/var/lib/mysql
+ mysql_logdir=/var/log/mysql
+ mysql_cfgdir=/etc/mysql
+ mysql_upgradedir=/var/lib/mysql-upgrade
+ '[' '!' -d /usr/share/mysql -a '!' -L /usr/share/mysql ']'
+ '[' '!' -d /var/lib/mysql -a '!' -L /var/lib/mysql ']'
+ mkdir /var/lib/mysql
+ '[' '!' -d /var/log/mysql -a '!' -L /var/log/mysql ']'
+ set +e
+ chown -R 0:0 /usr/share/mysql
+ chown -R mysql /var/lib/mysql
+ chown -R mysql:adm /var/log/mysql
+ chmod 2750 /var/log/mysql
+ set -e
+ db_set mariadb-server/postrm_remove_database false
+ _db_cmd 'SET mariadb-server/postrm_remove_database' false
+ _db_internal_IFS=' 
'
+ IFS=' '
+ printf '%s\n' 'SET mariadb-server/postrm_remove_database false'
+ IFS=' 
'
+ IFS='
'
+ read -r _db_internal_line
+ RET='10 mariadb-server/postrm_remove_database doesn'\''t exist'
+ case ${_db_internal_line%%[   ]*} in
+ return 10
+ true
+ rm -f '/var/lib/mysql/debian-*.flag'
+ touch /var/lib/mysql/debian-10.0.flag
+ set +e
+ bash /usr/bin/mysql_install_db --rpm --user=mysql --disable-log-bin
+ logger -p daemon.err -t mysqld_safe -i
+ set -e
+ dc=/etc/mysql/debian.cnf
++ fgrep debian-sys-maint /etc/mysql/debian.cnf
+ '[' '!' -e /etc/mysql/debian.cnf -o -n '' ']'
+ chown 0:0 /etc/mysql/debian.cnf
+ chmod 0600 /etc/mysql/debian.cnf
++ /bin/echo -e 'USE mysql;\n' 'SET sql_log_bin=0;\n' 'ALTER TABLE user CHANGE Password Password char(41) character set latin1 collate latin1_bin DEFAULT '\'''\'' NOT NULL;'
+ password_column_fix_query='USE mysql;
 SET sql_log_bin=0;
 ALTER TABLE user CHANGE Password Password char(41) character set latin1 collate latin1_bin DEFAULT '\'''\'' NOT NULL;'
+ echo 'USE mysql;
 SET sql_log_bin=0;
 ALTER TABLE user CHANGE Password Password char(41) character set latin1 collate latin1_bin DEFAULT '\'''\'' NOT NULL;'
+ /usr/sbin/mysqld --bootstrap --user=mysql --disable-log-bin --skip-grant-tables --default-storage-engine=myisam --plugin-load-add=auth_socket
+ logger -p daemon.err -t mysqld_safe -i
++ /bin/echo -e 'SET sql_mode='\'''\'', sql_log_bin=0;\n' 'DELETE FROM mysql.user WHERE user='\''debian-sys-maint'\'' AND host='\''localhost'\'';'
+ replace_query='SET sql_mode='\'''\'', sql_log_bin=0;
 DELETE FROM mysql.user WHERE user='\''debian-sys-maint'\'' AND host='\''localhost'\'';'
++ /bin/echo -e 'USE mysql;\n' 'SET sql_log_bin=0;\n' 'CREATE TABLE IF NOT EXISTS plugin (name char(64) COLLATE utf8_bin NOT NULL DEFAULT '\'''\'', ' '  dl char(128) COLLATE utf8_bin NOT NULL DEFAULT '\'''\'', ' '  PRIMARY KEY (name)) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT='\''MySQL plugins'\'';\n' 'INSTALL PLUGIN unix_socket SONAME '\''auth_socket'\'';\n'
+ install_plugins='USE mysql;
 SET sql_log_bin=0;
 CREATE TABLE IF NOT EXISTS plugin (name char(64) COLLATE utf8_bin NOT NULL DEFAULT '\'''\'',    dl char(128) COLLATE utf8_bin NOT NULL DEFAULT '\'''\'',    PRIMARY KEY (name)) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT='\''MySQL plugins'\'';
 INSTALL PLUGIN unix_socket SONAME '\''auth_socket'\'';'
+ set +e
+ echo 'USE mysql;
 SET sql_log_bin=0;
 CREATE TABLE IF NOT EXISTS plugin (name char(64) COLLATE utf8_bin NOT NULL DEFAULT '\'''\'',    dl char(128) COLLATE utf8_bin NOT NULL DEFAULT '\'''\'',    PRIMARY KEY (name)) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT='\''MySQL plugins'\'';
 INSTALL PLUGIN unix_socket SONAME '\''auth_socket'\'';'
+ /usr/sbin/mysqld --bootstrap --user=mysql --disable-log-bin --skip-grant-tables --default-storage-engine=myisam --plugin-load-add=auth_socket
+ logger -p daemon.err -t mysqld_safe -i
+ set -e
+ set_mysql_rootpw
++ mktemp
+ tfile=/tmp/tmp.jYYUVgSX9v
+ '[' '!' -f /tmp/tmp.jYYUVgSX9v ']'
+ cat
+ '[' '' = online ']'
+ /usr/sbin/mysqld --bootstrap --user=mysql --disable-log-bin --skip-grant-tables --default-storage-engine=myisam --plugin-load-add=auth_socket
+ retval=0
+ rm -f /tmp/tmp.jYYUVgSX9v
+ return 0
+ '[' -e ']'
+ rm -f
+ set +e
+ echo 'SET sql_mode='\'''\'', sql_log_bin=0;
 DELETE FROM mysql.user WHERE user='\''debian-sys-maint'\'' AND host='\''localhost'\'';'
+ /usr/sbin/mysqld --bootstrap --user=mysql --disable-log-bin --skip-grant-tables --default-storage-engine=myisam --plugin-load-add=auth_socket
+ logger -p daemon.err -t mysqld_safe -i
+ set -e
+ '[' configure = configure ']'
+ test_passwordless_root_login
+ mysql --no-defaults -u root -h localhost
+ set_mysql_rootpw online
++ mktemp
+ tfile=/tmp/tmp.xQDNY3SU5v
+ '[' '!' -f /tmp/tmp.xQDNY3SU5v ']'
+ cat
+ '[' online = online ']'
+ mysql --no-defaults -u root -h localhost
+ retval=0
+ rm -f /tmp/tmp.xQDNY3SU5v
+ return 0
+ '[' '' = yes ']'
+ db_stop
+ echo STOP
+ exit 0
Setting up mariadb-server (10.0.16-1) ...
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
        LANGUAGE = "",
        LC_ALL = (unset),
        LANG = "en_AU.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
        LANGUAGE = "",
        LC_ALL = (unset),
        LANG = "en_AU.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
locale: Cannot set LC_CTYPE to default locale: No such file or directory
locale: Cannot set LC_MESSAGES to default locale: No such file or directory
locale: Cannot set LC_ALL to default locale: No such file or directory
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
        LANGUAGE = "",
        LC_ALL = (unset),
        LANG = "en_AU.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").



root@spaceman:~# mysql
Welcome to the MariaDB monitor.  Commands end with ; or \g.
Your MariaDB connection id is 5
Server version: 10.0.17-MariaDB-1~exp1 (Debian)

Copyright (c) 2000, 2015, Oracle, MariaDB Corporation Ab and others.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

MariaDB [(none)]> show grants;
+------------------------------------------------------------------------------------------------+
| Grants for root@localhost                                                                      |
+------------------------------------------------------------------------------------------------+
| GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' IDENTIFIED VIA unix_socket WITH GRANT OPTION |
| GRANT PROXY ON ''@'%' TO 'root'@'localhost' WITH GRANT OPTION                                  |

</pre>