### PR TITLE
dont get mysql_install_db to tell the user to change the root password

### DIFF
--- a/debian/mariadb-server-10.0.postinst
+++ b/debian/mariadb-server-10.0.postinst
@@ -108,7 +108,7 @@ case "$1" in
     # Debian: beware of the bashisms...
     # Debian: can safely run on upgrades with existing databases
     set +e
-    bash /usr/bin/mysql_install_db --rpm --user=mysql --disable-log-bin 2>&1 | $ERR_LOGGER
+    bash /usr/bin/mysql_install_db --rpm --cross-bootstrap --user=mysql --disable-log-bin 2>&1 | $ERR_LOGGER
     set -e
 
     ## On every reconfiguration the maintenance user is recreated.


### PR DESCRIPTION
shoudl remove syslog message
<pre>
Mar 12 00:18:47 debunstable mysqld_safe[22082]: 
Mar 12 00:18:47 debunstable mysqld_safe[22082]: PLEASE REMEMBER TO SET A PASSWORD FOR THE MariaDB root USER ! 
Mar 12 00:18:47 debunstable mysqld_safe[22082]: To do so, start the server, then issue the following commands: 
Mar 12 00:18:47 debunstable mysqld_safe[22082]: 
Mar 12 00:18:47 debunstable mysqld_safe[22082]: '/usr/bin/mysqladmin' -u root password 'new-password' 
Mar 12 00:18:47 debunstable mysqld_safe[22082]: '/usr/bin/mysqladmin' -u root -h debunstable password 'new-password' 
Mar 12 00:18:47 debunstable mysqld_safe[22082]: 
Mar 12 00:18:47 debunstable mysqld_safe[22082]: Alternatively you can run: 
Mar 12 00:18:47 debunstable mysqld_safe[22082]: '/usr/bin/mysql_secure_installation' 
Mar 12 00:18:47 debunstable mysqld_safe[22082]: 
Mar 12 00:18:47 debunstable mysqld_safe[22082]: which will also give you the option of removing the test 
Mar 12 00:18:47 debunstable mysqld_safe[22082]: databases and anonymous user created by default.  This is 
Mar 12 00:18:47 debunstable mysqld_safe[22082]: strongly recommended for production servers. 
Mar 12 00:18:47 debunstable mysqld_safe[22082]: 
</pre>