### PR TITLE
oldconf undefined in some branches

### DIFF
--- a/debian/mariadb-server-10.0.postinst
+++ b/debian/mariadb-server-10.0.postinst
@@ -154,6 +154,8 @@ case "$1" in
         echo "password = "                                                 >>$dc
         echo "socket   = $mysql_rundir/mysqld.sock"                        >>$dc
         echo "basedir  = /usr"                                             >>$dc
+    else
+      oldconf=''
     fi
     # If this dir chmod go+w then the admin did it. But this file should not.
     chown 0:0 $dc


### PR DESCRIPTION

oldconf wasn't defined
<pre>
I ended up in a situation where $dc is not defined and the mv command fails:

+ set -e  
+ set_mysql_rootpw  
++ mktemp  
+ tfile=/tmp/tmp.0MXrfhgD7s  
+ '[' '!' -f /tmp/tmp.0MXrfhgD7s ']'  
+ cat  
+ '[' '' = online ']'  
+ /usr/sbin/mysqld --bootstrap --user=mysql --disable-log-bin --skip-grant-tables --default-storage-engine=myisam --plugin-load-add=auth_socket  
+ retval=1  
+ rm -f /tmp/tmp.0MXrfhgD7s  
+ return 1  
+ password_error=yes  
+ '[' -e ']'  
+ mv /etc/mysql/debian.cnf  
mv: missing destination file operand after '/etc/mysql/debian.cnf'  
Try 'mv --help' for more information.  
dpkg: error processing package mariadb-server-10.0 (--configure):  
 subprocess installed post-installation script returned error exit status 1  
Setting up libmysqlclient18:amd64 (5.5.42-1) ...  
Setting up libdbd-mysql-perl (4.028-2+b1) ...  
Processing triggers for libc-bin (2.19-13) ...  
Errors were encountered while processing:  
 mariadb-server-10.0  
E: Sub-process /usr/bin/dpkg returned an error code (1)  
</pre>