### PR TITLE
Remove skip-name-resolve

### DIFF
--- a/debian/mariadb-server-10.0.postinst
+++ b/debian/mariadb-server-10.0.postinst
@@ -205,16 +205,6 @@ esac
 # password wasn't set.  if there is a password, or if the connection
 # fails for any other reason, nothing happens.
 if [ "$1" = "configure" ]; then
-       # if there are no users with a hostname grant we can use skip-name-resolve
-       # this improves response time, especially if there are hosts connecting that don't
-       # have a reverse DNS resolution.
-       if [ -z `mysql --no-defaults -u root -h localhost -e \
-   "select host from mysql.user where not is_ipv6(host) and not is_ipv4(host) and host!='localhost' limit 1"` ];
-       then
-               umask 066
-               /bin/echo -e "[mariadb]\nskip-name-resolve" > $mysql_cfgdir/mariadb.conf.d/skip-name-resolve.cnf
-               umask 022
-       fi
 
        if [ "$password_error" = "yes" ]; then
                db_input high mariadb-server/error_setting_password || true


### PR DESCRIPTION
Good idea, but won't work. The server isn't running in the postinstall
and bootstrap can't get the result of queries.