### PR TITLE
Fix: upgrade fails when /var/lib/mysql is a soft link (#792918)

### DIFF
--- a/debian/mariadb-server-10.0.preinst
+++ b/debian/mariadb-server-10.0.preinst
@@ -141,7 +141,7 @@ for dir in DATADIR LOGDIR; do
     checkdir=`eval echo "$"$dir`
     if [ -L "$checkdir" ]; then
 	mkdir -p "$UPGRADEDIR"
-	cp -d "$checkdir" "$UPGRADEDIR/$dir.link"
+	cp -dT "$checkdir" "$UPGRADEDIR/$dir.link"
     fi
 done
 


### PR DESCRIPTION
The preinst script tries to copy the soft link under
/var/lib/mysql-upgrade/DATADIR.link. However, when the target link
exists from a previous upgrade, cp treats it as a target directory
rather than a target file name.
The -T flag tells cp to never treat the target as a directory.