### PR TITLE
Added a Debian default file for the mariadb-server-10.0 package

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+mariadb-10.0 (10.0.20-3+maria-1~jessie) jessie; urgency=medium
+
+  [ Jean Weisbuch ]
+  * Added a Debian default file for the mariadb-server-10.0 package which
+    allows to set the MYSQLD_STARTUP_TIMEOUT variable used in the init script
+
+ --  <jean@phpnet.org>  Tue, 21 Jul 2015 23:27:45 +0200
+
 mariadb-10.0 (10.0.20-3) UNRELEASED; urgency=medium
 
   [ Andreas Beckmann ]

--- a/debian/mariadb-server-10.0.default
+++ b/debian/mariadb-server-10.0.default
@@ -1,0 +1,4 @@
+# The delay in seconds the init script waits for the server to be up and running after having started "mysqld_safe" to run the "/etc/mysql/debian-start" script.
+# If the server is still not responding after the delay, the script won't be executed and an error will be thrown on the syslog.
+# Default: 30
+#MYSQLD_STARTUP_TIMEOUT=30

--- a/debian/mariadb-server-10.0.mysql.init
+++ b/debian/mariadb-server-10.0.mysql.init
@@ -28,6 +28,10 @@ MYADMIN="/usr/bin/mysqladmin --defaults-file=/etc/mysql/debian.cnf"
 # priority can be overriden and "-s" adds output to stderr
 ERR_LOGGER="logger -p daemon.err -t /etc/init.d/mysql -i"
 
+if [ -f /etc/default/mariadb-server-10.0 ] ; then
+        . /etc/default/mariadb-server-10.0
+fi
+
 # Safeguard (relative paths, core dumps..)
 cd /
 umask 077


### PR DESCRIPTION
The file allows to set the MYSQLD_STARTUP_TIMEOUT variable used in the init script

Please note that i haven't tried the package and as the default file use the same name as the package its installed with, it should create a file called "/etc/default/mariadb-server-10.0" which could be problematic for upgrade to 10.1 and further and i don't know what would be the best practice here.

For more infos about the ".default" file : https://www.debian.org/doc/manuals/maint-guide/dother.en.html#initd