### PR TITLE
MDEV-9091 mysqld crashes on shutdown after running TokuDB tests on Ubuntu

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 mariadb-10.0 (10.0.22-2~exp2) UNRELEASED; urgency=low
 
   [Alexander Barkov]
+  * A fix for "MDEV-9091 mysqld crashes on shutdown after running
+     TokuDB tests on Ubuntu"
   * Backport patch from upstream to fix MDEV-8692: prefschema test failures
 
   [Otto Kekäläinen]

--- a/debian/patches/mdev-9091-tokudb.patch
+++ b/debian/patches/mdev-9091-tokudb.patch
@@ -1,0 +1,28 @@
+Description: The patch fixes mysqld crash on shutdown when built
+with CFLAGS="-g -Wl,-Bsymbolic-functions" (which are enabled
+by default on Ubuntu when building packages).
+
+Remove this once upstream has released an official fix.
+Author: Alexander Barkov <bar@mariadb.org>
+Bug: https://mariadb.atlassian.net/browse/MDEV-9091
+
+
+diff --git a/storage/tokudb/ft-index/portability/CMakeLists.txt b/storage/tokudb/ft-index/portability/CMakeLists.txt
+index 9f84d9b..a356205 100644
+--- a/storage/tokudb/ft-index/portability/CMakeLists.txt
++++ b/storage/tokudb/ft-index/portability/CMakeLists.txt
+@@ -14,12 +14,12 @@ set(tokuportability_srcs
+   )
+ 
+ add_library(${LIBTOKUPORTABILITY} SHARED ${tokuportability_srcs})
+-target_link_libraries(${LIBTOKUPORTABILITY} LINK_PRIVATE ${LIBJEMALLOC})
++target_link_libraries(${LIBTOKUPORTABILITY})
+ target_link_libraries(${LIBTOKUPORTABILITY} LINK_PUBLIC ${CMAKE_THREAD_LIBS_INIT} ${EXTRA_SYSTEM_LIBS})
+ 
+ add_library(tokuportability_static_conv STATIC ${tokuportability_srcs})
+ set_target_properties(tokuportability_static_conv PROPERTIES POSITION_INDEPENDENT_CODE ON)
+-set(tokuportability_source_libs tokuportability_static_conv ${LIBJEMALLOC} ${CMAKE_THREAD_LIBS_INIT} ${EXTRA_SYSTEM_LIBS})
++set(tokuportability_source_libs tokuportability_static_conv ${CMAKE_THREAD_LIBS_INIT} ${EXTRA_SYSTEM_LIBS})
+ toku_merge_static_libs(${LIBTOKUPORTABILITY}_static ${LIBTOKUPORTABILITY}_static "${tokuportability_source_libs}")
+ 
+ maybe_add_gcov_to_libraries(${LIBTOKUPORTABILITY} tokuportability_static_conv)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -13,3 +13,4 @@ mysqld_multi.server_lsb-header.patch
 os_sync_free.patch
 mdev-7550-tokudb.patch
 mdev-8692-perf-arm.patch
+mdev-9091-tokudb.patch


### PR DESCRIPTION
Hi Otto,

Please merge an experimental patch which fixed the problem on my Ubuntu virtual machine.
The patch is not in the main MariaDB-10.0 tree yet.
