### PR TITLE
[MDEV-9479] oqgraph fails to build with boost 1.60

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mariadb-10.0 (10.0.25-1ubuntu1) unstable; urgency=low
+
+  * Fix oqgraph compilation failure when boost library is >= 1.60
+
+ -- Vicențiu Ciorbaru <cvicentiu@gmail.com>  Sun, 29 May 2016 17:19:58 +0300
+
 mariadb-10.0 (10.0.25-1) unstable; urgency=low
 
   * Revert previous changes tailored for Ubuntu 16.04 compatibility.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-mariadb-10.0 (10.0.25-1) UNRELEASED; urgency=low
+mariadb-10.0 (10.0.25-1) unstable; urgency=low
 
   * Revert previous changes tailored for Ubuntu 16.04 compatibility.
   * New upstream release 10.0.25. Includes fixes for the following
@@ -19,7 +19,7 @@ mariadb-10.0 (10.0.25-1) UNRELEASED; urgency=low
   * Updated Brazilian Portuguese translation (Closes: #824644).
   * Add patch to provide passwordless root accounts for test suite.
 
- -- Otto Kekäläinen <otto@debian.org>  Sat, 30 Apr 2016 21:00:18 +0300
+ -- Otto Kekäläinen <otto@debian.org>  Mon, 23 May 2016 16:08:52 +0300
 
 mariadb-10.0 (10.0.24-7) unstable; urgency=low
 

--- a/debian/patches/mdev-9479-oqgraph-boost.patch
+++ b/debian/patches/mdev-9479-oqgraph-boost.patch
@@ -1,0 +1,20 @@
+Make OQGraph compile with Boost 1.6
+Boost 1.6 changed the interface in boost::graph. Make sure to not use
+the now removed defines.
+
+This patch should be removed when upstream provides a fix.
+Author: Vicențiu Ciorbaru <cvicentiu@gmail.com>
+Bug: https://jira.mariadb.org/browse/MDEV-9479
+
+
+--- mariadb-10.0-10.0.25.orig/storage/oqgraph/oqgraph_shim.h
++++ mariadb-10.0-10.0.25/storage/oqgraph/oqgraph_shim.h
+@@ -254,7 +254,7 @@ namespace boost
+     typedef no_property type;
+   };
+ 
+-#if BOOST_VERSION >= 104601
++#if BOOST_VERSION >= 104601 && BOOST_VERSION < 106000
+   template <>
+   struct graph_bundle_type<oqgraph3::graph>
+   {

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -14,3 +14,4 @@ mdev-8375-passwordless-root-via-socket-auth.patch
 mdev-8375-built-in-auth-socket.patch
 mdev-8375-passwordless-accounts-for-testsuite.patch
 mdev-9528-mysql_embedded.patch
+mdev-9479-oqgraph-boost.patch


### PR DESCRIPTION
This is a patch to allow ubuntu yaketti compilation when boost's version is >= 1.6