### PR TITLE
Revert changes from 10.0.26 that caused regression on PowerPC

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,9 @@ mariadb-10.0 (10.0.26-1) unstable; urgency=low
   * New upstream release 10.0.26
   * Refresh patches after 10.0.26 import
 
+  [ Vicențiu Ciorbaru ]
+  * Revert innodb and xtradb PowerPC synchronization fix from upstream 10.0.26
+
  -- Otto Kekäläinen <otto@debian.org>  Fri, 24 Jun 2016 17:05:44 +0300
 
 mariadb-10.0 (10.0.25-1) unstable; urgency=low

--- a/debian/patches/innodb_xtradb_10.0.26_regression.patch
+++ b/debian/patches/innodb_xtradb_10.0.26_regression.patch
@@ -1,0 +1,34 @@
+Description: Revert innodb and xtradb PowerPC synchronization from 10.0.26
+  On PowerPC 64 Little Endian we have synchronization problems that causes
+  warnings in test cases. The patch reverts these changes from 10.0.26 that
+  caused this regression.
+  .
+  This patch should be removed when upstream provides an adequate fix.
+Author: Vicențiu Ciorbaru <vicentiu@mariadb.org>
+
+diff --git a/storage/innobase/include/os0sync.h b/storage/innobase/include/os0sync.h
+index 1cf4e9c..95e724e 100644
+--- a/storage/innobase/include/os0sync.h
++++ b/storage/innobase/include/os0sync.h
+@@ -466,7 +466,7 @@ amount to decrement. */
+ # define os_atomic_decrement_uint64(ptr, amount) \
+ 	os_atomic_decrement(ptr, amount)
+ 
+-# if defined(HAVE_ATOMIC_BUILTINS)
++# if defined(IB_STRONG_MEMORY_MODEL)
+ 
+ /** Do an atomic test and set.
+ @param[in,out]	ptr		Memory location to set to non-zero
+diff --git a/storage/xtradb/include/os0sync.h b/storage/xtradb/include/os0sync.h
+index 0f93f3f..dd808e8 100644
+--- a/storage/xtradb/include/os0sync.h
++++ b/storage/xtradb/include/os0sync.h
+@@ -517,7 +517,7 @@ amount to decrement. */
+ # define os_atomic_decrement_uint64(ptr, amount) \
+ 	os_atomic_decrement(ptr, amount)
+ 
+-# if defined(HAVE_ATOMIC_BUILTINS)
++# if defined(IB_STRONG_MEMORY_MODEL)
+ 
+ /** Do an atomic test and set.
+ @param[in,out]	ptr		Memory location to set to non-zero

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -15,3 +15,4 @@ mdev-8375-built-in-auth-socket.patch
 mdev-8375-passwordless-accounts-for-testsuite.patch
 mdev-9528-mysql_embedded.patch
 man_page_tokuftdump.patch
+innodb_xtradb_10.0.26_regression.patch


### PR DESCRIPTION
The recent changes in 10.0.26 caused a visible regression on PowerPC builders.
This is due to a synchronization error. The patch reverts the faulty
changes until upstream can provide an adequate fix.