### PR TITLE
Fix failing shutdown with gcc v6

### DIFF
--- a/debian/patches/mdev-10563-shutdown-failure.patch
+++ b/debian/patches/mdev-10563-shutdown-failure.patch
@@ -1,0 +1,185 @@
+Description: Prevent undefined behavior caused by dereferencing null pointers
+  GCC v6 has introduced the optimization that the "this" pointer is always
+  non-null and removes any if statements that are considered constant. This
+  introduces problems during shutdown as the if guard is removed. Move
+  the guards up a level, before calling the member functions.
+  .
+  This patch should be removed when upstream provides an adequate fix.
+Author: Vicențiu Ciorbaru <vicentiu@mariadb.org>
+diff --git a/sql/item_func.cc b/sql/item_func.cc
+index b637213..9ee1ba4 100644
+--- a/sql/item_func.cc
++++ b/sql/item_func.cc
+@@ -3942,7 +3942,7 @@ longlong Item_master_pos_wait::val_int()
+   longlong timeout = (arg_count>=3) ? args[2]->val_int() : 0 ;
+   String connection_name_buff;
+   LEX_STRING connection_name;
+-  Master_info *mi;
++  Master_info *mi= NULL;
+   if (arg_count >= 4)
+   {
+     String *con;
+@@ -3962,8 +3962,9 @@ longlong Item_master_pos_wait::val_int()
+     connection_name= thd->variables.default_master_connection;
+ 
+   mysql_mutex_lock(&LOCK_active_mi);
+-  mi= master_info_index->get_master_info(&connection_name,
+-                                         Sql_condition::WARN_LEVEL_WARN);
++  if (master_info_index)  // master_info_index is set to NULL on shutdown.
++    mi= master_info_index->get_master_info(&connection_name,
++                                           Sql_condition::WARN_LEVEL_WARN);
+   mysql_mutex_unlock(&LOCK_active_mi);
+   if (!mi)
+     goto err;
+diff --git a/sql/mysqld.cc b/sql/mysqld.cc
+index 4dfe456..79419fc 100644
+--- a/sql/mysqld.cc
++++ b/sql/mysqld.cc
+@@ -7316,7 +7316,10 @@ static int show_slaves_running(THD *thd, SHOW_VAR *var, char *buff)
+   var->value= buff;
+   mysql_mutex_lock(&LOCK_active_mi);
+ 
+-  *((longlong *)buff)= master_info_index->any_slave_sql_running();
++  if (master_info_index)
++    *((longlong *)buff)= master_info_index->any_slave_sql_running();
++  else
++    *((longlong *)buff)= 0;
+ 
+   mysql_mutex_unlock(&LOCK_active_mi);
+   return 0;
+diff --git a/sql/rpl_mi.cc b/sql/rpl_mi.cc
+index 9c6f463..249bf76 100644
+--- a/sql/rpl_mi.cc
++++ b/sql/rpl_mi.cc
+@@ -1095,8 +1095,6 @@ Master_info_index::get_master_info(LEX_STRING *connection_name,
+               connection_name->str));
+ 
+   mysql_mutex_assert_owner(&LOCK_active_mi);
+-  if (!this) // master_info_index is set to NULL on server shutdown
+-    DBUG_RETURN(NULL);
+ 
+   /* Make name lower case for comparison */
+   res= strmake(buff, connection_name->str, connection_name->length);
+@@ -1250,8 +1248,6 @@ bool Master_info_index::give_error_if_slave_running()
+ {
+   DBUG_ENTER("give_error_if_slave_running");
+   mysql_mutex_assert_owner(&LOCK_active_mi);
+-  if (!this) // master_info_index is set to NULL on server shutdown
+-    DBUG_RETURN(TRUE);
+ 
+   for (uint i= 0; i< master_info_hash.records; ++i)
+   {
+@@ -1282,8 +1278,7 @@ uint Master_info_index::any_slave_sql_running()
+ {
+   uint count= 0;
+   DBUG_ENTER("any_slave_sql_running");
+-  if (!this) // master_info_index is set to NULL on server shutdown
+-    DBUG_RETURN(count);
++  mysql_mutex_assert_owner(&LOCK_active_mi);
+ 
+   for (uint i= 0; i< master_info_hash.records; ++i)
+   {
+diff --git a/sql/slave.cc b/sql/slave.cc
+index 5d44fb2..9e882e1 100644
+--- a/sql/slave.cc
++++ b/sql/slave.cc
+@@ -649,6 +649,7 @@ int terminate_slave_threads(Master_info* mi,int thread_mask,bool skip_lock)
+     mysql_mutex_unlock(log_lock);
+   }
+   if (opt_slave_parallel_threads > 0 &&
++      master_info_index &&// master_info_index is set to NULL on server shutdown
+       !master_info_index->any_slave_sql_running())
+     rpl_parallel_inactivate_pool(&global_rpl_thread_pool);
+   if (thread_mask & (SLAVE_IO|SLAVE_FORCE_ALL))
+diff --git a/sql/sys_vars.cc b/sql/sys_vars.cc
+index 060441b..84a38c8 100644
+--- a/sql/sys_vars.cc
++++ b/sql/sys_vars.cc
+@@ -1538,7 +1538,8 @@ Sys_var_gtid_slave_pos::do_check(THD *thd, set_var *var)
+   }
+ 
+   mysql_mutex_lock(&LOCK_active_mi);
+-  running= master_info_index->give_error_if_slave_running();
++  running= (!master_info_index ||
++            master_info_index->give_error_if_slave_running());
+   mysql_mutex_unlock(&LOCK_active_mi);
+   if (running)
+     return true;
+@@ -1578,7 +1579,7 @@ Sys_var_gtid_slave_pos::global_update(THD *thd, set_var *var)
+ 
+   mysql_mutex_unlock(&LOCK_global_system_variables);
+   mysql_mutex_lock(&LOCK_active_mi);
+-  if (master_info_index->give_error_if_slave_running())
++  if (!master_info_index || master_info_index->give_error_if_slave_running())
+     err= true;
+   else
+     err= rpl_gtid_pos_update(thd, var->save_result.string_value.str,
+@@ -1767,7 +1768,8 @@ check_slave_parallel_threads(sys_var *self, THD *thd, set_var *var)
+   bool running;
+ 
+   mysql_mutex_lock(&LOCK_active_mi);
+-  running= master_info_index->give_error_if_slave_running();
++  running= (!master_info_index ||
++            master_info_index->give_error_if_slave_running());
+   mysql_mutex_unlock(&LOCK_active_mi);
+   if (running)
+     return true;
+@@ -1782,7 +1784,8 @@ fix_slave_parallel_threads(sys_var *self, THD *thd, enum_var_type type)
+ 
+   mysql_mutex_unlock(&LOCK_global_system_variables);
+   mysql_mutex_lock(&LOCK_active_mi);
+-  err= master_info_index->give_error_if_slave_running();
++  err= (!master_info_index ||
++        master_info_index->give_error_if_slave_running());
+   mysql_mutex_unlock(&LOCK_active_mi);
+   mysql_mutex_lock(&LOCK_global_system_variables);
+ 
+@@ -1809,7 +1812,8 @@ check_slave_domain_parallel_threads(sys_var *self, THD *thd, set_var *var)
+   bool running;
+ 
+   mysql_mutex_lock(&LOCK_active_mi);
+-  running= master_info_index->give_error_if_slave_running();
++  running= (!master_info_index ||
++            master_info_index->give_error_if_slave_running());
+   mysql_mutex_unlock(&LOCK_active_mi);
+   if (running)
+     return true;
+@@ -1824,7 +1828,8 @@ fix_slave_domain_parallel_threads(sys_var *self, THD *thd, enum_var_type type)
+ 
+   mysql_mutex_unlock(&LOCK_global_system_variables);
+   mysql_mutex_lock(&LOCK_active_mi);
+-  running= master_info_index->give_error_if_slave_running();
++  running= (!master_info_index ||
++            master_info_index->give_error_if_slave_running());
+   mysql_mutex_unlock(&LOCK_active_mi);
+   mysql_mutex_lock(&LOCK_global_system_variables);
+ 
+@@ -1862,7 +1867,8 @@ check_gtid_ignore_duplicates(sys_var *self, THD *thd, set_var *var)
+   bool running;
+ 
+   mysql_mutex_lock(&LOCK_active_mi);
+-  running= master_info_index->give_error_if_slave_running();
++  running= (!master_info_index ||
++            master_info_index->give_error_if_slave_running());
+   mysql_mutex_unlock(&LOCK_active_mi);
+   if (running)
+     return true;
+@@ -1877,7 +1883,8 @@ fix_gtid_ignore_duplicates(sys_var *self, THD *thd, enum_var_type type)
+ 
+   mysql_mutex_unlock(&LOCK_global_system_variables);
+   mysql_mutex_lock(&LOCK_active_mi);
+-  running= master_info_index->give_error_if_slave_running();
++  running= (!master_info_index ||
++            master_info_index->give_error_if_slave_running());
+   mysql_mutex_unlock(&LOCK_active_mi);
+   mysql_mutex_lock(&LOCK_global_system_variables);
+ 
+@@ -2830,7 +2837,7 @@ Sys_var_replicate_events_marked_for_skip::global_update(THD *thd, set_var *var)
+ 
+   mysql_mutex_unlock(&LOCK_global_system_variables);
+   mysql_mutex_lock(&LOCK_active_mi);
+-  if (!master_info_index->give_error_if_slave_running())
++  if (master_info_index && !master_info_index->give_error_if_slave_running())
+     result= Sys_var_enum::global_update(thd, var);
+   mysql_mutex_unlock(&LOCK_active_mi);
+   mysql_mutex_lock(&LOCK_global_system_variables);

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -18,3 +18,4 @@ mdev-9528-mysql_embedded.patch
 man_page_tokuftdump.patch
 innodb_xtradb_10.0.26_regression.patch
 mdev-10428-main-information-schema-stats-test-fix.patch
+mdev-10563-shutdown-failure.patch


### PR DESCRIPTION
Comparing the "this" pointer to NULL is always false in well defined
C++ code. This condition is optimized out by the compiler. We should
never call methods on object pointers that are NULL.