### PR TITLE
don't ignore files that are changed during build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,8 +227,6 @@ storage/mroonga/vendor/groonga/src/grnslap
 storage/mroonga/vendor/groonga/src/groonga
 storage/mroonga/vendor/groonga/src/groonga-benchmark
 storage/mroonga/vendor/groonga/src/suggest/groonga-suggest-create-dataset
-storage/mroonga/mysql-test/mroonga/storage/r/information_schema_plugins.result
-storage/mroonga/mysql-test/mroonga/storage/r/variable_version.result
 # C and C++
 
 # Compiled Object files


### PR DESCRIPTION
These files are changed during build, but are not removed/updated with 'git clean -d -f && git reset --hard' because they are ignored by git, which results in an error during the next build