### PR TITLE
Fix tokudb jemalloc linking

### DIFF
--- a/debian/patches/series
+++ b/debian/patches/series
@@ -16,3 +16,4 @@ mdev-8375-built-in-auth-socket.patch
 mdev-8375-passwordless-accounts-for-testsuite.patch
 mdev-9528-mysql_embedded.patch
 man_page_tokuftdump.patch
+tokudb_jemalloc_link.patch

--- a/debian/patches/tokudb_jemalloc_link.patch
+++ b/debian/patches/tokudb_jemalloc_link.patch
@@ -1,0 +1,26 @@
+Description: Do not link lib-jemalloc privately with TokuDB
+ Linking privately with lib-jemalloc causes problems when loading/unloading
+ tokudb, as lib-jemalloc sets some internal variables in thread local storage.
+ If tokudb gets unloaded, we lose the destructors to these variables and
+ subsequently crash.
+ .
+ Remove this once upstream has released an official fix.
+Author: Vicențiu Ciorbaru <vicentiu@mariadb.org>
+diff --git a/storage/tokudb/PerconaFT/portability/CMakeLists.txt b/storage/tokudb/PerconaFT/portability/CMakeLists.txt
+index 9f84d9b..4793db6 100644
+--- a/storage/tokudb/PerconaFT/portability/CMakeLists.txt
++++ b/storage/tokudb/PerconaFT/portability/CMakeLists.txt
+@@ -14,12 +14,11 @@ set(tokuportability_srcs
+   )
+ 
+ add_library(${LIBTOKUPORTABILITY} SHARED ${tokuportability_srcs})
+-target_link_libraries(${LIBTOKUPORTABILITY} LINK_PRIVATE ${LIBJEMALLOC})
+ target_link_libraries(${LIBTOKUPORTABILITY} LINK_PUBLIC ${CMAKE_THREAD_LIBS_INIT} ${EXTRA_SYSTEM_LIBS})
+ 
+ add_library(tokuportability_static_conv STATIC ${tokuportability_srcs})
+ set_target_properties(tokuportability_static_conv PROPERTIES POSITION_INDEPENDENT_CODE ON)
+-set(tokuportability_source_libs tokuportability_static_conv ${LIBJEMALLOC} ${CMAKE_THREAD_LIBS_INIT} ${EXTRA_SYSTEM_LIBS})
++set(tokuportability_source_libs tokuportability_static_conv ${CMAKE_THREAD_LIBS_INIT} ${EXTRA_SYSTEM_LIBS})
+ toku_merge_static_libs(${LIBTOKUPORTABILITY}_static ${LIBTOKUPORTABILITY}_static "${tokuportability_source_libs}")
+ 
+ maybe_add_gcov_to_libraries(${LIBTOKUPORTABILITY} tokuportability_static_conv)


### PR DESCRIPTION
Linking tokudb with jemalloc privately causes problems on library
load/unload. To prevent dangling destructor pointers, link with the same
library as the server is using.

This patch will fix our failures on AMD64.