### PR TITLE
Fix armhf regressions in 10.0.28

### DIFF
--- a/debian/patches/armhf_mroonga_storage_fail.patch
+++ b/debian/patches/armhf_mroonga_storage_fail.patch
@@ -1,0 +1,21 @@
+Description: Prevent unaligned memory access on armhf in mroonga storage engine
+ Make use of memcpy instead of straight pointer dereferencing. The surrounding
+ code uses the same logic and should be fixed upstream.
+Author: Vicențiu Ciorbaru <vicentiu@mariadb.org>
+
+diff --git a/storage/mroonga/lib/mrn_multiple_column_key_codec.cpp b/storage/mroonga/lib/mrn_multiple_column_key_codec.cpp
+index 1e55636..32b6a93 100644
+--- a/storage/mroonga/lib/mrn_multiple_column_key_codec.cpp
++++ b/storage/mroonga/lib/mrn_multiple_column_key_codec.cpp
+@@ -470,9 +470,10 @@ namespace mrn {
+     long long int long_long_value;
+     mrn_byte_order_host_to_network(&long_long_value, grn_key, data_size);
+     int max_bit = (data_size * 8 - 1);
+-    *((long long int *)mysql_key) =
++    long_long_value =
+       long_long_value ^ (((long_long_value ^ (1LL << max_bit)) >> max_bit) |
+                          (1LL << max_bit));
++    memcpy(mysql_key, &long_long_value, sizeof(long_long_value));
+     DBUG_VOID_RETURN;
+   }
+ 

--- a/debian/patches/armhf_upd_fail.patch
+++ b/debian/patches/armhf_upd_fail.patch
@@ -1,0 +1,27 @@
+Description: Prevent unaligned memory access on armhf in connect storage engine
+ Make use of memcpy instead of straight pointer dereferencing. The surrounding
+ code uses the same logic and should be fixed upstream.
+Author: Vicențiu Ciorbaru <vicentiu@mariadb.org>
+
+diff --git a/storage/connect/value.cpp b/storage/connect/value.cpp
+index 64d0e13..bef035d 100644
+--- a/storage/connect/value.cpp
++++ b/storage/connect/value.cpp
+@@ -796,7 +796,7 @@ uchar TYPVAL<uchar>::GetTypedValue(PVBLK blk, int n)
+ template <class TYPE>
+ void TYPVAL<TYPE>::SetBinValue(void *p)
+   {
+-  Tval = *(TYPE *)p;
++  memcpy(&Tval, p, sizeof(TYPE));
+   Null = false;
+   } // end of SetBinValue
+ 
+@@ -819,7 +819,7 @@ bool TYPVAL<TYPE>::GetBinValue(void *buf, int buflen, bool go)
+ //#endif
+ 
+   if (go)
+-    *(TYPE *)buf = Tval;
++    memcpy(buf, &Tval, sizeof(TYPE));
+ 
+   Null = false;
+   return false;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -22,3 +22,4 @@ mips-machine.patch
 mips-unstable-tests.patch
 hurd_socket.patch
 armhf_upd_fail.patch
+armhf_mroonga_storage_fail.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -21,3 +21,4 @@ mips-connect-unaligned.patch
 mips-machine.patch
 mips-unstable-tests.patch
 hurd_socket.patch
+armhf_upd_fail.patch


### PR DESCRIPTION
Hi Otto,

Here are the patches that fix both test failures on armhf. I expect we'll get more of these failures in the coming releases as much of the code does not care for memory alignment and we use similar constructs to the ones fixed here. It is just a matter of luck unfortunately. I will push for getting these tested and fixed in subsequent releases.