### PR TITLE
Fix innodb compilation when missing 64 builtin atomics

### DIFF
--- a/debian/patches/mdev-13009-fix-innodb-no-64-atomics.patch
+++ b/debian/patches/mdev-13009-fix-innodb-no-64-atomics.patch
@@ -1,0 +1,16 @@
+Description: Fix innodb compilation when missing 64 bit atomic builtins
+Author: Vicențiu Ciorbaru <vicentiu@mariadb.org>
+Last-Update: 2017-06-28
+
+diff --git a/storage/innobase/include/srv0mon.h b/storage/innobase/include/srv0mon.h
+index 09af5d4159..9c6f78c548 100644
+--- a/storage/innobase/include/srv0mon.h
++++ b/storage/innobase/include/srv0mon.h
+@@ -616,6 +616,7 @@ Use MONITOR_DEC if appropriate mutex protection exists.
+ # define srv_mon_create() ((void) 0)
+ # define srv_mon_free() ((void) 0)
+ #else /* HAVE_ATOMIC_BUILTINS_64 */
++#include "sync0types.h"
+ /** Mutex protecting atomic operations on platforms that lack
+ built-in operations for atomic memory access */
+ extern ib_mutex_t	monitor_mutex;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -13,3 +13,4 @@ mysqld_multi.server_lsb-header.patch
 mdev-8375-passwordless-root-via-socket-auth.patch
 mdev-8375-built-in-auth-socket.patch
 mdev-9528-mysql_embedded.patch
+mdev-13009-fix-innodb-no-64-atomics.patch


### PR DESCRIPTION
Port MDEV-13009 to 10.0. XtraDB does not require this patch because
include chain starting with univ.i already fetches ib_mutex_t
definition.